### PR TITLE
Refactor/provide option to return results prior to errors

### DIFF
--- a/lib/booker/client.rb
+++ b/lib/booker/client.rb
@@ -89,7 +89,9 @@ module Booker
       results = self.send(method, path, params, model)
 
       unless results.is_a?(Array)
-        raise Booker::MidPaginationError.new("Result from paginated request to #{path} with params: #{params} is not a collection", params, fetched)
+        error_msg = "Result from paginated request to #{path} with params: #{params} is not a collection"
+        raise Booker::MidPaginationError.new(message: error_msg, error_occurred_during_params: params,
+                                             results_fetched_prior_to_error: fetched)
       end
 
       fetched.concat(results)

--- a/lib/booker/client.rb
+++ b/lib/booker/client.rb
@@ -89,11 +89,7 @@ module Booker
       results = self.send(method, path, params, model)
 
       unless results.is_a?(Array)
-        error = StandardError.new("Result from paginated request to #{path} with params: #{params} is not a collection")
-        error.instance_variable_set(:@error_occurred_during_params, params)
-        error.instance_variable_set(:@results_prior_to_error, fetched)
-
-        raise error
+        raise Booker::MidPaginationError.new("Result from paginated request to #{path} with params: #{params} is not a collection", params, fetched)
       end
 
       fetched.concat(results)

--- a/lib/booker/client.rb
+++ b/lib/booker/client.rb
@@ -89,7 +89,11 @@ module Booker
       results = self.send(method, path, params, model)
 
       unless results.is_a?(Array)
-        raise StandardError, "Result from paginated request to #{path} with params: #{params} is not a collection"
+        error = StandardError.new("Result from paginated request to #{path} with params: #{params} is not a collection")
+        error.instance_variable_set(:@error_occurred_during_params, params)
+        error.instance_variable_set(:@results_prior_to_error, fetched)
+
+        raise error
       end
 
       fetched.concat(results)

--- a/lib/booker/errors.rb
+++ b/lib/booker/errors.rb
@@ -22,7 +22,7 @@ module Booker
   class MidPaginationError < StandardError
     attr_accessor :error_occurred_during_params, :results_fetched_prior_to_error, :message
 
-    def initialize(message="Error occurred during call mid-pagination", error_occurred_during_params={}, results_fetched_prior_to_error=[])
+    def initialize(message: "Error occurred during call mid-pagination", error_occurred_during_params: {}, results_fetched_prior_to_error: [])
       self.error_occurred_during_params = error_occurred_during_params
       self.results_fetched_prior_to_error = results_fetched_prior_to_error
       self.message = message

--- a/lib/booker/errors.rb
+++ b/lib/booker/errors.rb
@@ -19,6 +19,16 @@ module Booker
     end
   end
 
+  class MidPaginationError < StandardError
+    attr_accessor :error_occurred_during_params, :results_fetched_prior_to_error, :message
+
+    def initialize(message="Error occurred during call mid-pagination", error_occurred_during_params={}, results_fetched_prior_to_error=[])
+      self.error_occurred_during_params = error_occurred_during_params
+      self.results_fetched_prior_to_error = results_fetched_prior_to_error
+      self.message = message
+    end
+  end
+
   class InvalidApiCredentials < Error; end
   class ServiceUnavailable < Error; end
   class RateLimitExceeded < Error; end

--- a/lib/booker/errors/mid_pagination_error.rb
+++ b/lib/booker/errors/mid_pagination_error.rb
@@ -1,2 +1,0 @@
-class MidPaginationError
-end

--- a/lib/booker/errors/mid_pagination_error.rb
+++ b/lib/booker/errors/mid_pagination_error.rb
@@ -1,0 +1,2 @@
+class MidPaginationError
+end

--- a/lib/booker/version.rb
+++ b/lib/booker/version.rb
@@ -1,3 +1,3 @@
 module Booker
-  VERSION = '3.3.3'
+  VERSION = '3.3.4'
 end

--- a/spec/lib/booker/client_spec.rb
+++ b/spec/lib/booker/client_spec.rb
@@ -384,16 +384,19 @@ describe Booker::Client do
       let(:base_paginated_params) { {method: 'method', path: path, params: params, model: Booker::V4::Models::Model, fetch_all: true} }
       let(:pagination_params) { base_paginated_params }
       let(:result) { client.paginated_request(pagination_params) }
+      let(:error) do
+        Booker::MidPaginationError.new("Result from paginated request to #{path} with params: #{params} is not a collection", params, [])
+      end
 
       context 'first page returns a non-array' do
         before do
           expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return('foo')
-          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@error_occurred_during_params, params)
-          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@results_prior_to_error, [])
         end
 
         it 'raises error; returns hash of message, params, and results successfully fetched prior to error' do
-          expect{result}.to raise_error(StandardError, "Result from paginated request to #{path} with params: #{params} is not a collection")
+          expect{result}.to raise_error(Booker::MidPaginationError)
+          expect(error.error_occurred_during_params).to eq params
+          expect(error.results_fetched_prior_to_error).to eq([])
         end
       end
       context 'when fetched param is non-empty' do
@@ -402,15 +405,15 @@ describe Booker::Client do
         let(:error_page) { 'not an array' }
         let(:page_number) { 5 }
         let(:pagination_params) { base_paginated_params.merge({fetched: already_fetched}) }
+        let(:message) { "Result from paginated request to #{path} with params: #{params} is not a collection" }
 
         before do
           expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(error_page)
-          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@error_occurred_during_params, params)
-          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@results_prior_to_error, already_fetched)
+          expect(Booker::MidPaginationError).to receive(:new).with(message, params, already_fetched).and_call_original
         end
 
         it 'raises error; returns results prior to error' do
-          expect{result}.to raise_error(StandardError, "Result from paginated request to #{path} with params: {:UsePaging=>true, :PageSize=>2, :PageNumber=>5} is not a collection")
+          expect{result}.to raise_error(Booker::MidPaginationError)
         end
       end
     end

--- a/spec/lib/booker/client_spec.rb
+++ b/spec/lib/booker/client_spec.rb
@@ -373,18 +373,45 @@ describe Booker::Client do
     end
 
     context 'result is not a list' do
-      let(:params) {{
-        UsePaging: true,
-        PageSize: 2,
-        PageNumber: 1
-      }}
-
-      before do
-        expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return('foo')
+      let(:page_number) { 1 }
+      let(:params) do
+        {
+          UsePaging: true,
+          PageSize: 2,
+          PageNumber: page_number
+        }
       end
+      let(:base_paginated_params) { {method: 'method', path: path, params: params, model: Booker::V4::Models::Model, fetch_all: true} }
+      let(:pagination_params) { base_paginated_params }
+      let(:result) { client.paginated_request(pagination_params) }
 
-      it 'raises error' do
-        expect{client.paginated_request(method: 'method', path: path, params: params, model: Booker::V4::Models::Model)}.to raise_error(StandardError, "Result from paginated request to #{path} with params: {:UsePaging=>true, :PageSize=>2, :PageNumber=>1} is not a collection")
+      context 'first page returns a non-array' do
+        before do
+          expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return('foo')
+          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@error_occurred_during_params, params)
+          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@results_prior_to_error, [])
+        end
+
+        it 'raises error; returns hash of message, params, and results successfully fetched prior to error' do
+          expect{result}.to raise_error(StandardError, "Result from paginated request to #{path} with params: #{params} is not a collection")
+        end
+      end
+      context 'when fetched param is non-empty' do
+        let(:order_data) { 'A+ results' }
+        let(:already_fetched) { [order_data, order_data, order_data] }
+        let(:error_page) { 'not an array' }
+        let(:page_number) { 5 }
+        let(:pagination_params) { base_paginated_params.merge({fetched: already_fetched}) }
+
+        before do
+          expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(error_page)
+          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@error_occurred_during_params, params)
+          expect_any_instance_of(StandardError).to receive(:instance_variable_set).with(:@results_prior_to_error, already_fetched)
+        end
+
+        it 'raises error; returns results prior to error' do
+          expect{result}.to raise_error(StandardError, "Result from paginated request to #{path} with params: {:UsePaging=>true, :PageSize=>2, :PageNumber=>5} is not a collection")
+        end
       end
     end
   end

--- a/spec/lib/booker/client_spec.rb
+++ b/spec/lib/booker/client_spec.rb
@@ -384,8 +384,9 @@ describe Booker::Client do
       let(:base_paginated_params) { {method: 'method', path: path, params: params, model: Booker::V4::Models::Model, fetch_all: true} }
       let(:pagination_params) { base_paginated_params }
       let(:result) { client.paginated_request(pagination_params) }
+      let(:message) { "Result from paginated request to #{path} with params: #{params} is not a collection" }
       let(:error) do
-        Booker::MidPaginationError.new("Result from paginated request to #{path} with params: #{params} is not a collection", params, [])
+        Booker::MidPaginationError.new(message: message, error_occurred_during_params: params, results_fetched_prior_to_error: [])
       end
 
       context 'first page returns a non-array' do
@@ -409,7 +410,10 @@ describe Booker::Client do
 
         before do
           expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(error_page)
-          expect(Booker::MidPaginationError).to receive(:new).with(message, params, already_fetched).and_call_original
+          expect(Booker::MidPaginationError).to receive(:new).with(message: message,
+                                                                   error_occurred_during_params:  params,
+                                                                   results_fetched_prior_to_error: already_fetched
+            ).and_call_original
         end
 
         it 'raises error; returns results prior to error' do

--- a/spec/lib/booker/errors_spec.rb
+++ b/spec/lib/booker/errors_spec.rb
@@ -81,24 +81,23 @@ describe Booker::MidPaginationError do
 
   describe '.new' do
     let(:error) { Booker::MidPaginationError.new(message, error_occurred_during_params, results_fetched_prior_to_error) }
-
+    let(:message) { "Error occurred during call mid-pagination" }
     before do
       expect(error.error_occurred_during_params).to eq error_occurred_during_params
       expect(error.results_fetched_prior_to_error).to eq results_fetched_prior_to_error
       expect(error.message).to eq message
     end
 
-    context 'when all atRtrs defined' do
+    context 'when all attributes defined' do
       let(:error_occurred_during_params) { {PageSize: 1} }
       let(:results_fetched_prior_to_error) { ['prior results'] }
       let(:message) { "Special message" }
 
       it 'sets error data' do; end
     end
-    context 'when attrs undefined' do
+    context 'when attributes undefined' do
       let(:error_occurred_during_params) { {} }
       let(:results_fetched_prior_to_error) { [] }
-      let(:message) { "Error occurred during call mid-pagination" }
 
       it 'sets defaults' do; end
     end

--- a/spec/lib/booker/errors_spec.rb
+++ b/spec/lib/booker/errors_spec.rb
@@ -69,6 +69,42 @@ describe Booker::Error do
   end
 end
 
+describe Booker::MidPaginationError do
+  describe 'attributes' do
+    it { expect(subject).to respond_to :error_occurred_during_params }
+    it { expect(subject).to respond_to :results_fetched_prior_to_error }
+    it { expect(subject).to respond_to :message }
+    it { expect(subject).to respond_to :error_occurred_during_params= }
+    it { expect(subject).to respond_to :results_fetched_prior_to_error= }
+    it { expect(subject).to respond_to :message= }
+  end
+
+  describe '.new' do
+    let(:error) { Booker::MidPaginationError.new(message, error_occurred_during_params, results_fetched_prior_to_error) }
+
+    before do
+      expect(error.error_occurred_during_params).to eq error_occurred_during_params
+      expect(error.results_fetched_prior_to_error).to eq results_fetched_prior_to_error
+      expect(error.message).to eq message
+    end
+
+    context 'when all atRtrs defined' do
+      let(:error_occurred_during_params) { {PageSize: 1} }
+      let(:results_fetched_prior_to_error) { ['prior results'] }
+      let(:message) { "Special message" }
+
+      it 'sets error data' do; end
+    end
+    context 'when attrs undefined' do
+      let(:error_occurred_during_params) { {} }
+      let(:results_fetched_prior_to_error) { [] }
+      let(:message) { "Error occurred during call mid-pagination" }
+
+      it 'sets defaults' do; end
+    end
+  end
+end
+
 describe Booker::InvalidApiCredentials do
   it 'should be a Booker::Error' do
     expect(Booker::InvalidApiCredentials.new).to be_a(Booker::Error)

--- a/spec/lib/booker/errors_spec.rb
+++ b/spec/lib/booker/errors_spec.rb
@@ -80,7 +80,10 @@ describe Booker::MidPaginationError do
   end
 
   describe '.new' do
-    let(:error) { Booker::MidPaginationError.new(message, error_occurred_during_params, results_fetched_prior_to_error) }
+    let(:error) do
+      Booker::MidPaginationError.new(message: message, error_occurred_during_params: error_occurred_during_params,
+                                     results_fetched_prior_to_error: results_fetched_prior_to_error)
+    end
     let(:message) { "Error occurred during call mid-pagination" }
     before do
       expect(error.error_occurred_during_params).to eq error_occurred_during_params


### PR DESCRIPTION
- Added new class of StandardError to capture params and results fetched from previous pages in pagination loop