### PR TITLE
Add 'message' method onto Booker::Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ BOOKER_API_DEBUG = false # Set to true to print request details to the log
 To ease development, **the gem points to Booker's API Sandbox at apicurrent-app.booker.ninja by default**.
 For production, you must set BOOKER_API_BASE_URL to https://api.booker.com.
 
+## Errors
+
+The `booker_ruby` gem provides a myriad of methods with useful error information on its [Booker::Error](https://github.com/HireFrederick/booker_ruby/blob/master/lib/booker/errors.rb#L3).
+These include: message, error, description, url, request, and response.
+
 ## Using Booker::Client
 
 A client subclass is available for each API:

--- a/lib/booker/errors.rb
+++ b/lib/booker/errors.rb
@@ -1,6 +1,6 @@
 module Booker
   class Error < StandardError
-    attr_accessor :error, :description, :url, :request, :response
+    attr_accessor :error, :description, :url, :request, :response, :message
 
     def initialize(url: nil, request: nil, response: nil)
       if request.present?
@@ -13,8 +13,10 @@ module Booker
           self.error = response.parsed_response['error'] || response.parsed_response['ErrorMessage']
           self.description = response.parsed_response['error_description']
         end
+        error_msg_from_response = self.response.try(:parsed_response) || self.response
       end
 
+      self.message = error_msg_from_response || "Error occurred, but no response was returned."
       self.url = url
     end
   end

--- a/lib/booker/version.rb
+++ b/lib/booker/version.rb
@@ -1,3 +1,3 @@
 module Booker
-  VERSION = '3.3.9'
+  VERSION = '3.3.10'
 end

--- a/spec/lib/booker/errors_spec.rb
+++ b/spec/lib/booker/errors_spec.rb
@@ -7,15 +7,18 @@ describe Booker::Error do
     it { expect(subject).to respond_to :description }
     it { expect(subject).to respond_to :request }
     it { expect(subject).to respond_to :response }
+    it { expect(subject).to respond_to :message }
     it { expect(subject).to respond_to :url= }
     it { expect(subject).to respond_to :error= }
     it { expect(subject).to respond_to :description= }
     it { expect(subject).to respond_to :request= }
     it { expect(subject).to respond_to :response= }
+    it { expect(subject).to respond_to :message= }
   end
 
   describe '.new' do
     let(:response) { instance_double(HTTParty::Response, parsed_response: parsed_response) }
+    let(:no_response_error_msg) { "Error occurred, but no response was returned." }
 
     context 'response is present' do
       let(:error) { Booker::Error.new(response: response) }
@@ -28,10 +31,11 @@ describe Booker::Error do
         }
       end
 
-      it 'sets error data' do
+      it 'sets error data; message is set to full parsed response' do
         expect(error.error).to eq 'error'
         expect(error.description).to eq 'description'
         expect(error.request).to be_nil
+        expect(error.message).to eq(parsed_response)
       end
 
       context 'when error is not present, but ErrorMessage is' do
@@ -45,6 +49,7 @@ describe Booker::Error do
         it 'sets error data' do
           expect(error.error).to eq 'ErrorMessage'
           expect(error.description).to eq 'description'
+          expect(error.message).to eq(parsed_response)
         end
       end
     end
@@ -56,6 +61,7 @@ describe Booker::Error do
         expect(error.request).to eq 'foo'
         expect(error.error).to be_nil
         expect(error.description).to be_nil
+        expect(error.message).to eq(no_response_error_msg)
       end
     end
 
@@ -64,6 +70,7 @@ describe Booker::Error do
 
       it 'sets url' do
         expect(error.url).to eq 'foo'
+        expect(error.message).to eq(no_response_error_msg)
       end
     end
   end


### PR DESCRIPTION
Unbeknownst to us, despite writing this gem, the Booker::Error error returns a plethora of information when the `response`, `request`, `url` attributes are utilized. Most errors respond to the `message` attribute, however, whereas our standard Booker::Error does not. Our Sentry messages and codebase, unfortunately, reflects this.

This PR enables developers to call `error.message` for more intuitive error message capturing.

I've also updated the documentation to make our error methods easier to find and implement.