### PR TITLE
Combine read timeout error with midpagination error for paginated_request method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    booker_ruby (4.0.0)
+    booker_ruby (3.4.0)
       activesupport (>= 3.0.0)
       httparty (>= 0.14)
       jwt (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    booker_ruby (3.3.13)
+    booker_ruby (4.3.17)
       activesupport (>= 3.0.0)
       httparty (>= 0.14)
       jwt (~> 1.5)
@@ -19,7 +19,7 @@ GEM
       activesupport (>= 3.0.0)
     concurrent-ruby (1.1.3)
     diff-lcs (1.3)
-    httparty (0.18.0)
+    httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.1.1)
@@ -27,10 +27,10 @@ GEM
     jwt (1.5.6)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2020.0512)
     minitest (5.11.3)
     multi_xml (0.6.0)
-    oj (3.10.5)
+    oj (3.10.6)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    booker_ruby (4.3.17)
+    booker_ruby (4.0.0)
       activesupport (>= 3.0.0)
       httparty (>= 0.14)
       jwt (~> 1.5)
@@ -30,7 +30,7 @@ GEM
     mime-types-data (3.2020.0512)
     minitest (5.11.3)
     multi_xml (0.6.0)
-    oj (3.10.6)
+    oj (3.10.7)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/lib/booker/client.rb
+++ b/lib/booker/client.rb
@@ -96,7 +96,11 @@ module Booker
 
       puts "fetching #{path} with #{params.except(:access_token)}. #{fetched.length} results so far."
 
-      results = self.send(method, path, params, model)
+      begin
+        results = self.send(method, path, params, model)
+      rescue Net::ReadTimeout
+        results = nil
+      end
 
       unless results.is_a?(Array)
         error_msg = "Result from paginated request to #{path} with params: #{params} is not a collection"

--- a/lib/booker/version.rb
+++ b/lib/booker/version.rb
@@ -1,3 +1,3 @@
 module Booker
-  VERSION = '4.0.0'
+  VERSION = '3.4.0'
 end

--- a/lib/booker/version.rb
+++ b/lib/booker/version.rb
@@ -1,3 +1,3 @@
 module Booker
-  VERSION = '3.3.17'
+  VERSION = '4.3.17'
 end

--- a/lib/booker/version.rb
+++ b/lib/booker/version.rb
@@ -1,3 +1,3 @@
 module Booker
-  VERSION = '4.3.17'
+  VERSION = '4.0.0'
 end

--- a/spec/lib/booker/client_spec.rb
+++ b/spec/lib/booker/client_spec.rb
@@ -430,13 +430,14 @@ describe Booker::Client do
       let(:pagination_params) { base_paginated_params }
       let(:result) { client.paginated_request(pagination_params) }
       let(:message) { "Result from paginated request to #{path} with params: #{params} is not a collection" }
+      let(:results_fetched_prior_to_error) { [] }
       let(:error) do
-        Booker::MidPaginationError.new(message: message, error_occurred_during_params: params, results_fetched_prior_to_error: [])
+        Booker::MidPaginationError.new(message: message, error_occurred_during_params: params, results_fetched_prior_to_error: results_fetched_prior_to_error)
       end
 
       context 'first page returns a non-array' do
         before do
-          expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return('foo')
+          allow(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return('foo')
         end
 
         it 'raises error; returns hash of message, params, and results successfully fetched prior to error' do
@@ -445,24 +446,62 @@ describe Booker::Client do
           expect(error.results_fetched_prior_to_error).to eq([])
         end
       end
+
       context 'when fetched param is non-empty' do
         let(:order_data) { 'A+ results' }
-        let(:already_fetched) { [order_data, order_data, order_data] }
+        let(:results_fetched_prior_to_error) { [order_data, order_data, order_data] }
         let(:error_page) { 'not an array' }
         let(:page_number) { 5 }
-        let(:pagination_params) { base_paginated_params.merge({fetched: already_fetched}) }
+        let(:pagination_params) { base_paginated_params.merge({fetched: results_fetched_prior_to_error}) }
         let(:message) { "Result from paginated request to #{path} with params: #{params} is not a collection" }
 
         before do
-          expect(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(error_page)
-          expect(Booker::MidPaginationError).to receive(:new).with(message: message,
+          allow(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(error_page)
+          allow(Booker::MidPaginationError).to receive(:new).with(message: message,
                                                                    error_occurred_during_params:  params,
-                                                                   results_fetched_prior_to_error: already_fetched
-            ).and_call_original
+                                                                   results_fetched_prior_to_error: results_fetched_prior_to_error
+          ).and_call_original
         end
 
         it 'raises error; returns results prior to error' do
           expect{result}.to raise_error(Booker::MidPaginationError)
+          expect(error.results_fetched_prior_to_error).to eq(results_fetched_prior_to_error)
+        end
+      end
+
+      context 'first page returns a read timeout error' do
+        let(:timeout_error) { Net::ReadTimeout }
+
+        before do
+          allow(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(timeout_error)
+        end
+
+        it 'raises booker error; returns hash of message, params, and results successfully fetched prior to error' do
+          expect{result}.to raise_error(Booker::MidPaginationError)
+          expect(error.error_occurred_during_params).to eq params
+          expect(error.results_fetched_prior_to_error).to eq([])
+        end
+      end
+
+      context 'when read timeout happens mid pagination' do
+        let(:order_data) { 'A+ results' }
+        let(:results_fetched_prior_to_error) { [order_data, order_data, order_data] }
+        let(:timeout_error) { Net::ReadTimeout }
+        let(:page_number) { 5 }
+        let(:pagination_params) { base_paginated_params.merge({fetched: results_fetched_prior_to_error}) }
+        let(:message) { "Result from paginated request to #{path} with params: #{params} is not a collection" }
+
+        before do
+          allow(client).to receive(:send).with('method', path, params, Booker::V4::Models::Model).and_return(timeout_error)
+          allow(Booker::MidPaginationError).to receive(:new).with(message: message,
+                                                                   error_occurred_during_params:  params,
+                                                                   results_fetched_prior_to_error: results_fetched_prior_to_error
+          ).and_call_original
+        end
+
+        it 'raises booker error; returns results prior to error' do
+          expect{result}.to raise_error(Booker::MidPaginationError)
+          expect(error.results_fetched_prior_to_error).to eq(results_fetched_prior_to_error)
         end
       end
     end


### PR DESCRIPTION
This is a minor version bump because we are rescuing `Net::ReadTimeout` errors for the method `paginated_request` to raise a `Booker::MidPaginationError`. 